### PR TITLE
Candidate Detail Changes

### DIFF
--- a/src/components/Candidatedetail.vue
+++ b/src/components/Candidatedetail.vue
@@ -1,755 +1,1177 @@
 <template>
-    <div class="modal fade" :class="['modal-mask', 'show', 'd-block']" tabindex="-1" aria-labelledby="exampleModalLabel"
-        aria-hidden="true">
-        <div class="modal-dialog h-100 mw-80" style="max-width: 90%">
-            <div class="modal-content modal-dialog-scrollable">
-                <div class="row justify-content-center align-items-center m-0">
-                    <!-- Candidate Detail (Left Side) -->
-                    <div id="leftColumn" class="col-7 mb-4">
-                        <UIPageHeaderResponsive>
-                            <template #preHeaderActions>
-                                <div class="me-2"></div>
-                                <div class="me-2">
-                                <img
-                                    class="image avatar-text-45"
-                                    v-if="candidateDetail?.profilepic || candidateDetail?.profilepicUrl"
-                                    :src="candidateDetail?.profilepicUrl?.split(',')[0] || candidateDetail?.profilepic?.split(',')[0]"
-                                    alt=""
-                                >
-                                    <div v-else
-                                        class="avatar-text-45 bg-candidate color-candidate">
-                                        <span>
-                                            {{ getAcronym(candidateDetail.candidatename) }}
-                                        </span>
-                                    </div>
-                                </div>
-                            </template>
-                            <template #pageHeader>
-                                <div class="row">
-                                    <span class="fwt-bold fs-16">{{ candidateDetail.candidatename
-                                    }}</span>
-                                    <div class="fs-12 fwt-bold">
-                                        <span class="text-muted d-none">
-                                            Submitted 2 days ago
-                                        </span>
-                                    </div>
-                                </div>
-                            </template>
-                            <template #pageActionsRight>
-                                <div class="d-flex justify-content-end">
-                                    <div class="text-end me-2 d-grid" v-if="visibilityOfStage">
-                                        <span class="text-muted fwt-bold mb-2">Agency Hiring Stage </span>
-                                        <span v-if="checkVisiblity('candidatestatus')"
-                                            class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold">{{
-                                                    jobData.candidateHiringStages.externalPipeline
-                                            }}</span>
-                                    </div>
-                                    <div class="vr me-2" v-if="visibilityOfStage && isPortalViewDisabled"></div>
-                                    <div v-if="isPortalViewDisabled">
-                                        <div class="d-grid" v-if="jobData.jobCandidatesById.addedToInternalPipeline">
-                                            <span class="text-muted fwt-bold mb-2">Internal Hiring Stage</span>
-                                            <span class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold">
-                                                {{jobData.candidateHiringStages.internalPipeline}}
-                                            </span>
-                                        </div>
-                                        <div class="mt-2" v-else>
-                                            <button
-                                                v-if="ability.can(abilities.UPDATE, accessControlModules.CANDIDATES)"
-                                                id="sTest_mapToJobBtn"
-                                                class="btn btn-icon-text border fwt-bold"
-                                                @click="addToInternalPipeline">
-                                                <em class='bx bx-plus me-1'></em>
-                                                Add to Internal Pipeline
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </template>
-                        </UIPageHeaderResponsive>
-                        <!-- Job Information Card -->
-                        <div class="card mt-4" >
-                            <div class="card-body">
-                                <h5 class="card-title">Job Information</h5>
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold">
-                                        Job Name
-                                    </div>
-                                    <div class="col-9 fwt-bold">
-                                        <div class="avatar-text-45 bg-job color-job me-2"
-                                            v-if="jobData.jobById.name">
-                                            <span>
-                                                {{ getAcronym(jobData.jobById.name) }}
-                                            </span>
-                                        </div>
-                                        {{ getCandidateDetail(jobData.jobById.name) }}
-                                    </div>
-                                </div>
-                                <hr />
-                                <!-- later in internal hiring pipeline -->
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold">
-                                       {{ isPortalViewDisabled ? 'Hiring Manager(s)' : 'Collaborators(s)'}}
-                                    </div>
-                                    <div class="col-9 d-inline-flex align-items-center flex-wrap" v-if="jobData.jobById.hiring_managers.length!=0">
-                                        <div v-for="(hiringmanager, index) in jobData.jobById.hiring_managers" :key="index" class="me-5 d-flex align-items-center mt-2">
-                                            <div class="me-2" v-if="(hiringmanager.photo != null)">
-                                                <img :src="hiringmanager.profile_url" class="rounded-circle" width="40" height="40" :class="{'d-none':isLoading}" />
-                                                <div :class="{'spinner-border':isLoading}" role="status" >
-                                                    <span class="visually-hidden">Loading...</span>
-                                                </div>
-                                            </div>
-                                            <div v-else class="avatar-text-45 bg-hiringManager color-hiringManager me-2">
-                                                <span>
-                                                    {{ getAcronym(hiringmanager.name) }}
-                                                </span>
-                                            </div>
-                                            <div>
-                                                <span class="fwt-bold d-flex">{{hiringmanager.name}}</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div v-else class="col-3">
-                                        Not Available
-                                    </div>
-                        
-                                </div>
-                            </div>
+  <div
+    class="modal fade"
+    :class="['modal-mask', 'show', 'd-block']"
+    tabindex="-1"
+    aria-labelledby="exampleModalLabel"
+    aria-hidden="true"
+  >
+    <div class="modal-dialog h-100 mw-80" style="max-width: 90%">
+      <div class="modal-content modal-dialog-scrollable">
+        <div class="row justify-content-center align-items-center m-0">
+          <!-- Candidate Detail (Left Side) -->
+          <div id="leftColumn" class="col-9 mb-4">
+            <UIPageHeaderResponsive>
+              <template #preHeaderActions>
+                <div class="me-2"></div>
+                <div class="me-2">
+                  <img
+                    class="image avatar-text-45"
+                    v-if="
+                      candidateDetail?.profilepic ||
+                        candidateDetail?.profilepicUrl
+                    "
+                    :src="
+                      candidateDetail?.profilepicUrl?.split(',')[0] ||
+                        candidateDetail?.profilepic?.split(',')[0]
+                    "
+                    alt=""
+                  />
+                  <div
+                    v-else
+                    class="avatar-text-45 bg-candidate color-candidate"
+                  >
+                    <span>
+                      {{ getAcronym(candidateDetail.candidatename) }}
+                    </span>
+                  </div>
+                </div>
+              </template>
+              <template #pageHeader>
+                <div class="row">
+                  <span class="fwt-bold fs-16">{{
+                    candidateDetail.candidatename
+                  }}</span>
+                  <div
+                    class="fs-12 fwt-bold d-flex align-items-center justify-content-start mt-1"
+                  >
+                    <div
+                      v-if="
+                        checkVisiblity('emailid') && candidateDetail['emailid']
+                      "
+                      class="me-4"
+                    >
+                      <img
+                        src="@/assets/images/mail.svg"
+                        alt="No Records Found"
+                      />
+                      <span class="ms-1 fs-13 text-muted">
+                        {{ getCandidateDetail(candidateDetail.emailid) }}
+                      </span>
+                    </div>
+                    <div
+                      v-if="
+                        checkVisiblity('contactnumber') &&
+                          candidateDetail['contactnumber']
+                      "
+                    >
+                      <img
+                        src="@/assets/images/phone.svg"
+                        alt="No Records Found"
+                      />
+                      <span class="ms-1 text-muted">
+                        {{ getCandidateDetail(candidateDetail.contactnumber) }}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <template #pageActionsRight>
+                <div class="d-flex justify-content-end">
+                  <div class="text-end me-2 d-grid" v-if="visibilityOfStage">
+                    <span class="text-muted fwt-bold mb-2"
+                      >Agency Hiring Stage
+                    </span>
+                    <span
+                      v-if="checkVisiblity('candidatestatus')"
+                      class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold"
+                      >{{
+                        jobData.candidateHiringStages.externalPipeline
+                      }}</span
+                    >
+                  </div>
+                  <div
+                    class="vr me-2"
+                    v-if="visibilityOfStage && isPortalViewDisabled"
+                  ></div>
+                  <div v-if="isPortalViewDisabled">
+                    <div
+                      class="d-grid"
+                      v-if="jobData.jobCandidatesById.addedToInternalPipeline"
+                    >
+                      <span class="text-muted fwt-bold mb-2"
+                        >Internal Hiring Stage</span
+                      >
+                      <span
+                        class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold"
+                      >
+                        {{ jobData.candidateHiringStages.internalPipeline }}
+                      </span>
+                    </div>
+                    <div class="mt-2" v-else>
+                      <button
+                        v-if="
+                          ability.can(
+                            abilities.UPDATE,
+                            accessControlModules.CANDIDATES
+                          )
+                        "
+                        id="sTest_mapToJobBtn"
+                        class="btn btn-icon-text border fwt-bold"
+                        @click="addToInternalPipeline"
+                      >
+                        <em class="bx bx-plus me-1"></em>
+                        Add to Internal Pipeline
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </UIPageHeaderResponsive>
+            <div class="card mt-4">
+              <div class="card-body p-3">
+                <h5 class="card-title pt-1">Candidate Details</h5>
+                <div class="row d-flex align-items-center p-3">
+                  <div
+                    v-for="(column, columnKey) in allVisibleFields"
+                    :key="columnKey"
+                    class="col-6 margin-check"
+                  >
+                    <div class="row">
+                      <div class="col-6 fwt-bold">
+                        {{ column.label }}
+                      </div>
+                      <div v-if="isCustomField(columnKey)" class="col-6">
+                        <div
+                          v-if="
+                            candidateDetail[columnKey].column_type == 'file'
+                          "
+                        >
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-if="
+                              candidateDetail[columnKey].column_value != null
+                            "
+                            @click="
+                              viewFileModal(
+                                candidateDetail[columnKey].column_value
+                              )
+                            "
+                          >
+                            <em
+                              class="bx bxs-file bx-sm"
+                              style="color:#2517d8"
+                            ></em>
+                          </button>
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-else
+                          >
+                            <em class="bx bx-file-blank bx-sm"></em>
+                          </button>
                         </div>
-                        <!-- Agency Information Card -->
-                        <div class="card mt-4">
-                            <div class="card-body">
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold" v-if="isPortalViewDisabled">
-                                        Agency Name
-                                    </div>
-                                    <div class="col-3" v-if="isPortalViewDisabled">
-                                        {{ getCandidateDetail(candidateDetail.agency_name)  }}
-                                    </div>
-                                    <div class="col-3 fwt-bold">
-                                        Submitted By
-                                    </div>
-                                    <div class="col-3"> 
-                                        {{ getCandidateDetail(candidateDetail.agency_contact_name) }}
-                                    </div>
-                                </div>
-                                <hr />
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold">
-                                        {{ candidateDetailsFields.candidateupdatedon }}
-                                    </div>
-                                    <div class="col-3">
-                                        {{ getCandidateDetail(candidateDetail.candidateupdatedon ,'candidateupdatedon') }}
-                                    </div>
-                                    <div class="col-3 fwt-bold" v-if="isPortalViewDisabled">
-                                        Department
-                                    </div>
-                                    <div class="col-3" v-if="isPortalViewDisabled">
-                                        {{ jobData.jobById.department_name?jobData.jobById.department_name:'Not Added' }}
-                                    </div>
-                                </div>
-                            </div>
+                        <div
+                          v-else-if="
+                            candidateDetail[columnKey].column_type == 'longtext'
+                          "
+                        >
+                          <span>{{
+                            candidateDetail[columnKey].column_value
+                              ? $truncate(
+                                  candidateDetail[columnKey].column_value,
+                                  { length: 15 }
+                                )
+                              : "Not Available"
+                          }}</span>
+                          <a
+                            v-if="candidateDetail[columnKey].column_value"
+                            href="#"
+                            class="ms-1 stretched-link position-relative"
+                            @click="
+                              openLongTextModal(candidateDetail[columnKey])
+                            "
+                            >View More</a
+                          >
                         </div>
-                        <!-- Candidate's Contact Information Card -->
-                        <div class="card mt-4" v-if="objCandidateDetailsSections.isCandidateContactInformationSectionVisible.visible || objCandidateDetailsSections.isSocialLinksSectionVisible.visible">
-                            <div class="card-body">
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold d-flex align-items-center"
-                                        v-if="checkVisiblity('emailid')">
-                                        <em class="bx bxs-envelope text-muted me-2 bx-sm"></em>
-                                        {{ candidateDetailsFields.emailid }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('emailid')">
-                                        {{ getCandidateDetail(candidateDetail.emailid) }}
-                                    </div>
-                                    <div class="col-3 fwt-bold d-flex align-items-center"
-                                        v-if="checkVisiblity('contactnumber')">
-                                        <em class="bx bxs-phone-call text-muted me-2 bx-sm"></em>
-                                        {{ candidateDetailsFields.contactnumber }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('contactnumber')">
-                                        {{ getCandidateDetail(candidateDetail.contactnumber) }}
-                                    </div>
-                                </div>
-                                <hr
-                                    :class="{ 'd-none': ((!checkVisiblity('emailid') && !checkVisiblity('contactnumber')) || !objCandidateDetailsSections.isSocialLinksSectionVisible.visible )}" />
-                                <div class="row d-flex align-items-center" v-if="objCandidateDetailsSections.isSocialLinksSectionVisible.visible">
-                                    <div class="col-3 fwt-bold d-flex align-items-center">
-                                        <em class="bx bx-share-alt text-muted me-2 bx-sm"></em> Social
-                                    </div>
-                                    <div class="col-3" v-if="socialFieldsHasValue">
-                                        <ul class="social-links">
-                                            <li v-if="checkVisiblity('profilelinkedin') && candidateDetail.profilelinkedin"><a id="sTest-candidateDLinkedinLink"
-                                                v-bind:href="getUrlProtocol(candidateDetail.profilelinkedin)" target="_blank"
-                                                class="me-2" rel="noopener noreferrer"><em class="bx bxl-linkedin-square bx-sm" style="color:#0077b5"></em></a>
-                                            </li>
-                                            <li v-if="checkVisiblity('profiletwitter') && candidateDetail.profiletwitter"><a id="sTest-candidateDTwitterLink"
-                                                v-bind:href="getUrlProtocol(candidateDetail.profiletwitter)" target="_blank"
-                                                class="me-2" rel="noopener noreferrer"><em class="bx bxl-twitter bx-sm" style="color:#006dbf"  ></em></a>
-                                            </li>
-                                            <li v-if="checkVisiblity('profilefacebook') && candidateDetail.profilefacebook"><a id="sTest-candidateDFbLink"
-                                                v-bind:href="getUrlProtocol(candidateDetail.profilefacebook)" target="_blank"
-                                                class="me-2" rel="noopener noreferrer"><em class="bx bxl-facebook-circle bx-sm" style="color:#3b5998" ></em></a>
-                                            </li>
-                                            <li v-if="checkVisiblity('profilegithub') && candidateDetail.profilegithub"><a id="sTest-candidateDGithubLink"
-                                                v-bind:href="getUrlProtocol(candidateDetail.profilegithub)" target="_blank"
-                                                class="me-2" rel="noopener noreferrer"><em class="bx bxl-github bx-sm" style="color:#040404"></em></a>
-                                            </li>
-                                            <li v-if="checkVisiblity('profilexing') && candidateDetail.profilexing"><a id="sTest-candidateDXingLink"
-                                                v-bind:href="getUrlProtocol(candidateDetail.profilexing)" target="_blank"
-                                                class="me-2" rel="noopener noreferrer"><em class="bx bxl-xing bx-sm" style="color:#06989d"  ></em></a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                    <div v-else class="col-3">
-                                        Not Available
-                                    </div>
-                                    
-                                </div>
-                            </div>
+                        <div v-else>
+                          <span
+                            v-if="
+                              candidateDetail[columnKey].column_type == 'date'
+                            "
+                            >{{
+                              candidateDetail[columnKey].column_value
+                                ? getDate(
+                                    candidateDetail[columnKey].column_value
+                                  )
+                                : "Not Available"
+                            }}</span
+                          >
+                          <span
+                            v-else-if="
+                              candidateDetail[columnKey].column_type ==
+                                'checkbox'
+                            "
+                            >{{
+                              candidateDetail[columnKey].column_value
+                                ? candidateDetail[columnKey].column_value == 1
+                                  ? "Yes"
+                                  : "No"
+                                : "Not Available"
+                            }}</span
+                          >
+                          <span
+                            v-else
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            :data-bs-title="
+                              candidateDetail[columnKey].column_value
+                            "
+                            data-bs-custom-class="custom-tooltip"
+                            >{{
+                              candidateDetail[columnKey].column_value
+                                ? $truncate(
+                                    candidateDetail[columnKey].column_value,
+                                    { length: 15 }
+                                  )
+                                : "Not Available"
+                            }}
+                          </span>
                         </div>
-                        <!-- Candidate's Personal Information Card -->
-                        <div class="card mt-4" v-if="objCandidateDetailsSections.isCandidatePersonalInformationSectionVisible.visible">
-                            <div class="card-body">
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('candidate_city')">
-                                        {{ candidateDetailsFields.candidate_city }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('candidate_city')">
-                                        {{ getCandidateDetail(candidateDetail.candidate_city) }}
-                                    </div>
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('candidate_locality')">
-                                        {{ candidateDetailsFields.candidate_locality }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('candidate_locality')">
-                                        {{ getCandidateDetail(candidateDetail.candidate_locality) }}
-                                    </div>
-                                </div>
-                                <hr
-                                    :class="{ 'd-none': !checkVisiblity('candidate_city') && !checkVisiblity('candidate_locality') }" />
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('candidatedob')">
-                                        {{ candidateDetailsFields.candidatedob }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('candidatedob')">
-                                        {{ getDate(getCandidateDetail(candidateDetail.candidatedob)) }}
-                                    </div>
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('willingtorelocate')">
-                                        {{ candidateDetailsFields.willingtorelocate }}
-                                    </div>
-                                    <div class="col-3" v-if="checkVisiblity('willingtorelocate')">
-                                        {{ getCandidateDetail(candidateDetail.willingtorelocate == 1 ? 'Yes' : 'No') }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Profile Field's Card -->
-                        <div class="card mt-4" v-if="objCandidateDetailsSections.isProfileFieldsSectionVisible.visible">
-                            <div class="card-body">
-                                <h5 class="card-title pb-3">Profile Fields</h5>
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('languageskills')">
-                                        {{ candidateDetailsFields.languageskills }}
-                                    </div>
-                                    <div class="col-9" v-if="checkVisiblity('languageskills')">
-                                        {{  getCandidateDetail(candidateDetail.languageskills) }}
-                                    </div>
-                                </div>
-                                <hr :class="{ 'd-none': !checkVisiblity('languageskills') }" />
-                                <div class="row d-flex align-items-center">
-                                    <div class="col-3 fwt-bold" v-if="checkVisiblity('skill')">
-                                        {{ candidateDetailsFields.skill }}
-                                    </div>
-                                    <div class="col-9 fwt-bold" v-if="checkVisiblity('skill')">
-                                        <span class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold me-2 my-1"
-                                            v-for="(skill, index) in skills" :key="index">{{ skill }}</span>
-                                    </div>
-                                </div>
-                                <hr :class="{ 'd-none': !checkVisiblity('skill') }" />
-                                <div class="row d-flex align-items-center">
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('qualification')">
-                                        {{ candidateDetailsFields.qualification }}
-                                    </span>
-                                    <span class="col-9 " v-if="checkVisiblity('qualification')">
-                                        {{ getCandidateDetail(candidateDetail.qualification) }}
-                                    </span>
-                                </div>
-                                <hr :class="{ 'd-none': !checkVisiblity('qualification') }" />
-                                <div class="row d-flex align-items-center">
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('specialization')">
-                                        {{ candidateDetailsFields.specialization }}
-                                    </span>
-                                    <span class="col-9 " v-if="checkVisiblity('specialization')">
-                                        {{ getCandidateDetail(candidateDetail.specialization) }}
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Employment Information Card -->
-                        <div class="card mt-4" v-if="objCandidateDetailsSections.isEmploymentInformationSectionVisibile.visible">
-                            <div class="card-body">
-                                <h5 class="card-title pb-3">Employment Information</h5>
-                                <div class="row d-flex align-items-center">
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('workexpyr')">
-                                        {{ candidateDetailsFields.workexpyr }}
-                                    </span>
-                                    <span class="col-3" v-if="checkVisiblity('workexpyr')">
-                                        {{ getCandidateDetail(candidateDetail.workexpyr, 'Years') }}
-                                    </span>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('relevantexperience')">
-                                        {{ candidateDetailsFields.relevantexperience }}
-                                    </span>
-                                    <span class="col-3" v-if="checkVisiblity('relevantexperience')">
-                                        {{ getCandidateDetail(candidateDetail.relevantexperience, 'Years') }}
-                                    </span>
-                                </div>
-                                <hr
-                                    :class="{ 'd-none': !checkVisiblity('workexpyr') && !checkVisiblity('relevantexperience') }" />
+                      </div>
 
-                                <div class="row d-flex align-items-center">
-                                    <span class="col-3 fwt-bold" >
-                                        Salary Type
-                                    </span>
-                                    <span class="col-3" >
-                                        {{ getCandidateDetail(candidateDetail.salarytype, 'salaryType') }}
-                                    </span>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('lastorganisation')">
-                                        {{ candidateDetailsFields.lastorganisation }}
-                                    </span>
-                                    <span class="col-3" v-if="checkVisiblity('lastorganisation')">
-                                        {{ getCandidateDetail(candidateDetail.lastorganisation) }}
-                                    </span>
-                                </div>
-                                <hr/>
-                                <div v-if="checkVisiblity('salaryexpectation')" class="row d-flex align-items-center">
-                                    <span class="col-3 fwt-bold" >
-                                        Salary Expectation
-                                    </span>
-                                    <span class="col-3" >
-                                        {{ (candidateDetail.salaryexpectation != 0 ? getCandidateDetail(candidateDetail.symbol) : '') + getCandidateDetail(candidateDetail.salaryexpectation) }}
-                                    </span>
-                                </div>
-                                <hr :class="{ 'd-none': !checkVisiblity('salaryexpectation') }" />
+                      <span
+                        v-else-if="fileTypes.includes(columnKey)"
+                        class="col-6 d-flex align-items-center"
+                      >
+                        <div v-if="columnKey == 'summary'">
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-if="candidateDetail[columnKey]"
+                            @click="viewSummaryModal"
+                          >
+                            <img
+                              src="@/assets/images/summary-icon-filled.svg"
+                              alt=""
+                              width="20"
+                              height="20"
+                            />
+                          </button>
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-else
+                          >
+                            <img
+                              src="@/assets/images/summary-icon-blank.svg"
+                              alt=""
+                              width="20"
+                              height="20"
+                            />
+                          </button>
+                        </div>
+                        <div v-else>
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-if="candidateDetail[columnKey] != null"
+                            @click="viewFileModal(candidateDetail[columnKey])"
+                          >
+                            <em
+                              class="bx bxs-file bx-sm"
+                              style="color:#2517d8"
+                            ></em>
+                          </button>
+                          <button
+                            class="btn btn-icon justify-content-start me-2"
+                            v-else
+                          >
+                            <em class="bx bx-file-blank bx-sm"></em>
+                          </button>
+                        </div>
+                      </span>
 
-								<div class="row d-flex align-items-center">
-									<span class="col-3 fwt-bold" v-if="checkVisiblity('currentsalary')">
-										{{ candidateDetailsFields.currentsalary }}
-									</span>
-									<span class="col-3" v-if="checkVisiblity('currentsalary')">
-										{{ (candidateDetail.currentsalary != 0 ? getCandidateDetail(candidateDetail.symbol) : '') + getCandidateDetail(candidateDetail.currentsalary) }}
-									</span>
-									<span class="col-3 fwt-bold" v-if="checkVisiblity('availablefrom')">
-										{{ candidateDetailsFields.availablefrom }}
-									</span>
-									<span class="col-3" v-if="checkVisiblity('availablefrom')">
-										{{ getDate(getCandidateDetail(candidateDetail.availablefrom)) }}
-									</span>
-								</div>
-								<hr
-									:class="{ 'd-none': !checkVisiblity('currentsalary') && !checkVisiblity('availablefrom') }" />
-								<div class="row d-flex align-items-center">
-									<span class="col-3 fwt-bold" v-if="checkVisiblity('noticeperiod')">
-										{{ candidateDetailsFields.noticeperiod }}
-									</span>
-									<span class="col-3" v-if="checkVisiblity('noticeperiod')">
-										{{ getCandidateDetail(candidateDetail.noticeperiod, 'Days') }}
-									</span>
-								</div>
-							</div>
-						</div>
-						<!-- Files Card -->
-						<div class="card mt-4" v-if="objCandidateDetailsSections.isFilesSectionVisible.visible">
-							<div class="card-body">
-								<h5 class="card-title pb-3">Files</h5>
-								<div class="row d-flex align-items-center">
-									<span class="col-3 fwt-bold" v-if="checkVisiblity('resumefilename')">
-										Resume
-									</span>
-									<span class="col-9 d-flex align-items-center" v-if="checkVisiblity('resumefilename')">
-										<button class='btn btn-icon me-2' v-if="candidateDetail.resumefilename != null" @click="viewFileModal(candidateDetail.resumefilename,'showCandidateResumeModal')" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-										<button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button> 
-									</span>
-                                    <hr :class="{ 'd-none': !checkVisiblity('resumefilename') }"/>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('coverletter')">
-										Job Application Cover Letter
-									</span>
-									<span class="col-9 d-flex align-items-center"  v-if="checkVisiblity('coverletter')">
-										<button class='btn btn-icon me-2' v-if="candidateDetail.coverletter != null" @click="viewFileModal(candidateDetail.coverletter)" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-										<button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button> 
-									</span>
-                                    <hr :class="{ 'd-none': !checkVisiblity('coverletter') }"/>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('formatted_cv')">
-                                        Job Application Resume
-                                    </span>
-                                    <span class="col-9 d-flex align-items-center" v-if="checkVisiblity('formatted_cv')">
-                                        <button class='btn btn-icon me-2' v-if="candidateDetail.formatted_cv != null" @click="viewFileModal(candidateDetail.formatted_cv)" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-                                        <button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button>
-                                    </span>
-                                    <hr :class="{ 'd-none': !checkVisiblity('formatted_cv') }"/>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('other_file_1')">
-                                        Job Application File 1
-                                    </span>
-                                    <span class="col-9 d-flex align-items-center" v-if="checkVisiblity('other_file_1')">
-                                        <button class='btn btn-icon me-2' v-if="candidateDetail.other_file_1 != null" @click="viewFileModal(candidateDetail.other_file_1)" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-                                        <button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button>
-                                    </span>
-                                    <hr :class="{ 'd-none': !checkVisiblity('other_file_1') }"/>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('other_file_2')">
-                                        Job Application File 2
-                                    </span>
-                                    <span class="col-9 d-flex align-items-center" v-if="checkVisiblity('other_file_2')">
-                                        <button class='btn btn-icon me-2' v-if="candidateDetail.other_file_2 != null" @click="viewFileModal(candidateDetail.other_file_2)" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-                                        <button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button>
-                                    </span>
-                                    <hr :class="{ 'd-none': !checkVisiblity('other_file_2') }"/>
-                                    <span class="col-3 fwt-bold" v-if="checkVisiblity('portfolio')">
-                                        Job Application Portfolio
-                                    </span>
-                                    <span class="col-9 d-flex align-items-center" v-if="checkVisiblity('portfolio')">
-                                        <button class='btn btn-icon me-2' v-if="candidateDetail.portfolio != null" @click="viewFileModal(candidateDetail.portfolio)" ><em class='bx bxs-file bx-sm' style="color:#2517d8"></em></button>
-                                        <button class='btn btn-icon me-2' v-else ><em class='bx bx-file-blank bx-sm'></em></button>
-                                    </span>                                   
-								</div>
-							</div>
-						</div>
-						<!-- Additional Information-->
-						<CustomFieldsComponent @showFileModal="viewFileModal" :metaData="metaDataForNonSharedCandidates" />
-					</div>
-					<!-- Candidate Feedback (Right Side) -->
-					<div id="rightColumn" class="col-5 border-start">
-						<div class="modal-header">
-							<h5 class="modal-title">Candidate Feedback</h5>
-							<button id="sTest_closeCandidateDetailMdl" type="button" class="btn-close"
-								aria-label="Close"
-								@click="closeCandidateDetailsModal"></button>
-						</div>
-						<HiringStageFeedbackComponent :candidateDetails="candidateDetail" :fromInternalPipeline="isfromInternalPipeline" :visibilityHiringStage="visibilityInHiringStage" :vmsJobId="jobData.jobById.id" :kanbanType="kanbanType" @updateStageEventHappened="hiringStageChanged">
-						</HiringStageFeedbackComponent>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+                      <div v-else class="col-6">
+                        <span
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="top"
+                          :data-bs-title="
+                            getCandidateDetail(
+                              candidateDetail[columnKey],
+                              columnKey,
+                              column.type
+                            )
+                          "
+                          data-bs-custom-class="custom-tooltip"
+                        >
+                          {{
+                            $truncate(
+                              getCandidateDetail(
+                                candidateDetail[columnKey],
+                                columnKey,
+                                column.type
+                              ),
+                              { length: 15 }
+                            )
+                          }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col-6 margin-check" v-if="socialFieldsHasValue">
+                    <div class="row">
+                      <div class="col-6 fwt-bold d-flex align-items-center">
+                        Social
+                      </div>
+                      <div class="col-6" v-if="socialFieldsHasValue">
+                        <ul class="social-links mt-auto">
+                          <li
+                            v-if="
+                              checkVisiblity('profilelinkedin') &&
+                                candidateDetail.profilelinkedin
+                            "
+                          >
+                            <a
+                              id="sTest-candidateDLinkedinLink"
+                              v-bind:href="
+                                getUrlProtocol(candidateDetail.profilelinkedin)
+                              "
+                              target="_blank"
+                              class="me-2"
+                              rel="noopener noreferrer"
+                              ><em
+                                class="bx bxl-linkedin-square bx-sm"
+                                style="color:#0077b5"
+                              ></em
+                            ></a>
+                          </li>
+                          <li
+                            v-if="
+                              checkVisiblity('profiletwitter') &&
+                                candidateDetail.profiletwitter
+                            "
+                          >
+                            <a
+                              id="sTest-candidateDTwitterLink"
+                              v-bind:href="
+                                getUrlProtocol(candidateDetail.profiletwitter)
+                              "
+                              target="_blank"
+                              class="me-2"
+                              rel="noopener noreferrer"
+                              ><em
+                                class="bx bxl-twitter bx-sm"
+                                style="color:#006dbf"
+                              ></em
+                            ></a>
+                          </li>
+                          <li
+                            v-if="
+                              checkVisiblity('profilefacebook') &&
+                                candidateDetail.profilefacebook
+                            "
+                          >
+                            <a
+                              id="sTest-candidateDFbLink"
+                              v-bind:href="
+                                getUrlProtocol(candidateDetail.profilefacebook)
+                              "
+                              target="_blank"
+                              class="me-2"
+                              rel="noopener noreferrer"
+                              ><em
+                                class="bx bxl-facebook-circle bx-sm"
+                                style="color:#3b5998"
+                              ></em
+                            ></a>
+                          </li>
+                          <li
+                            v-if="
+                              checkVisiblity('profilegithub') &&
+                                candidateDetail.profilegithub
+                            "
+                          >
+                            <a
+                              id="sTest-candidateDGithubLink"
+                              v-bind:href="
+                                getUrlProtocol(candidateDetail.profilegithub)
+                              "
+                              target="_blank"
+                              class="me-2"
+                              rel="noopener noreferrer"
+                              ><em
+                                class="bx bxl-github bx-sm"
+                                style="color:#040404"
+                              ></em
+                            ></a>
+                          </li>
+                          <li
+                            v-if="
+                              checkVisiblity('profilexing') &&
+                                candidateDetail.profilexing
+                            "
+                          >
+                            <a
+                              id="sTest-candidateDXingLink"
+                              v-bind:href="
+                                getUrlProtocol(candidateDetail.profilexing)
+                              "
+                              target="_blank"
+                              class="me-2"
+                              rel="noopener noreferrer"
+                              ><em
+                                class="bx bxl-xing bx-sm"
+                                style="color:#06989d"
+                              ></em
+                            ></a>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-if="allVisibleFieldsLength % 2 != 0"
+                    class="col-6 margin-check"
+                  >
+                    <div class="row">
+                      <div class="col-12 fwt-bold invisible">
+                        Placeholder text
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="col-12 margin-check"
+                    v-if="checkVisiblity('languageskills')"
+                  >
+                    <div class="row">
+                      <div class="col-3 fwt-bold">
+                        {{ candidateDetailsFields.languageskills }}
+                      </div>
+                      <div class="col-9">
+                        <ul class="list-style-disc mb-0 ps-3">
+                          <li
+                            v-for="(language, columnKey) in languageSkillsList"
+                            :key="columnKey"
+                          >
+                            {{ language }}
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="col-12 margin-check"
+                    v-if="checkVisiblity('skill')"
+                  >
+                    <div class="row">
+                      <div class="col-3 fwt-bold">
+                        {{ candidateDetailsFields.skill }}
+                      </div>
+                      <div class="col-9">
+                        <span v-if="!candidateDetail.skill">Not Available</span>
+                        <span
+                          v-else
+                          class="badge rounded-pill stage-badge p-2 fs-12 fwt-bold me-2 my-1"
+                          v-for="(skill, columnKey) in getCandidateDetail(
+                            candidateDetail.skill,
+                            'skill'
+                          )"
+                          :key="columnKey"
+                          >{{ skill }}</span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <CandidateWorkHistory
+              v-if="
+                checkVisiblity('work_history') &&
+                  flagsmithData.workAndEducationFlag &&
+                  !isfromInternalPipeline
+              "
+              class="mt-4"
+              :candidateDetails="candidateDetail"
+              isFromProfileView="true"
+            ></CandidateWorkHistory>
+            <CandidateEducationHistory
+              v-if="
+                checkVisiblity('education_history') &&
+                  flagsmithData.workAndEducationFlag &&
+                  !isfromInternalPipeline
+              "
+              class="mt-4"
+              :candidateDetails="candidateDetail"
+              isFromProfileView="true"
+            ></CandidateEducationHistory>
+            <!-- Job Information Card -->
+            <div class="card mt-4">
+              <div class="card-body">
+                <h5 class="card-title">Job Information</h5>
+                <div class="row d-flex align-items-center ps-2">
+                  <div class="col-3 fwt-bold">
+                    Job Name
+                  </div>
+                  <div class="col-9 fwt-bold">
+                    <div
+                      class="avatar-text-45 bg-job color-job me-2"
+                      v-if="jobData.jobById.name"
+                    >
+                      <span>
+                        {{ getAcronym(jobData.jobById.name) }}
+                      </span>
+                    </div>
+                    {{ getCandidateDetail(jobData.jobById.name) }}
+                  </div>
+                </div>
+                <hr />
+                <!-- later in internal hiring pipeline -->
+                <div class="row d-flex align-items-center ps-2">
+                  <div class="col-3 fwt-bold">
+                    {{
+                      isPortalViewDisabled
+                        ? "Hiring Manager(s)"
+                        : "Collaborators(s)"
+                    }}
+                  </div>
+                  <div
+                    class="col-9 d-inline-flex align-items-center flex-wrap"
+                    v-if="jobData.jobById.hiring_managers.length != 0"
+                  >
+                    <div
+                      v-for="(hiringmanager, index) in jobData.jobById
+                        .hiring_managers"
+                      :key="index"
+                      class="me-5 d-flex align-items-center mt-2"
+                    >
+                      <div class="me-2" v-if="hiringmanager.photo != null">
+                        <img
+                          :src="hiringmanager.profile_url"
+                          class="rounded-circle"
+                          width="40"
+                          height="40"
+                          :class="{ 'd-none': isLoading }"
+                        />
+                        <div
+                          :class="{ 'spinner-border': isLoading }"
+                          role="status"
+                        >
+                          <span class="visually-hidden">Loading...</span>
+                        </div>
+                      </div>
+                      <div
+                        v-else
+                        class="avatar-text-45 bg-hiringManager color-hiringManager me-2"
+                      >
+                        <span>
+                          {{ getAcronym(hiringmanager.name) }}
+                        </span>
+                      </div>
+                      <div>
+                        <span class="fwt-bold d-flex">{{
+                          hiringmanager.name
+                        }}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div v-else class="col-3">
+                    Not Available
+                  </div>
+                </div>
+                <hr />
+                <div class="row d-flex align-items-center ps-2">
+                  <div class="col-3 fwt-bold">
+                    Submitted By
+                  </div>
+                  <div class="col-3">
+                    {{
+                      getCandidateDetail(candidateDetail.agency_contact_name)
+                    }}
+                  </div>
+                  <div class="col-3 fwt-bold">
+                    {{ candidateDetailsFields.candidateupdatedon }}
+                  </div>
+                  <div class="col-3">
+                    {{
+                      getCandidateDetail(
+                        candidateDetail.candidateupdatedon,
+                        "candidateupdatedon",
+                        "date"
+                      )
+                    }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- Candidate Feedback (Right Side) -->
+          <div id="rightColumn" class="col-3 border-start">
+            <div class="modal-header">
+              <h5 class="modal-title">Candidate Feedback</h5>
+              <button
+                id="sTest_closeCandidateDetailMdl"
+                type="button"
+                class="btn-close"
+                aria-label="Close"
+                @click="closeCandidateDetailsModal"
+              ></button>
+            </div>
+            <HiringStageFeedbackComponent
+              :candidateDetails="candidateDetail"
+              :fromInternalPipeline="isfromInternalPipeline"
+              :visibilityHiringStage="visibilityInHiringStage"
+              :vmsJobId="jobData.jobById.id"
+              :kanbanType="kanbanType"
+              @updateStageEventHappened="hiringStageChanged"
+            >
+            </HiringStageFeedbackComponent>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <LongTextDisplayModal
+    v-if="showLongTextModal"
+    :strModalTitle="strLongTextFieldName"
+    :strModalBody="strLongTextFieldValue"
+    @closeLongTextModal="showLongTextModal = false"
+  ></LongTextDisplayModal>
+  <HTMLViewer
+    v-if="openCandidateSummaryModal == true"
+    @closeHtmlModal="openCandidateSummaryModal = false"
+    entity="summary"
+  ></HTMLViewer>
 </template>
 
 <script>
 import UIPageHeaderResponsive from "@/components/UI/UIPageHeaderResponsive.vue";
 import HiringStageFeedbackComponent from "@/views/Candidates/HiringStageFeedbackComponent.vue";
+import LongTextDisplayModal from "@/components/LongTextDisplayModal.vue";
 import { useRecruitmentManager } from "@/composables/useRecruitmentManager";
 import { useCandidates } from "@/composables/useCandidates";
 import { useJobsStore } from "@/store/jobStore";
-import { inject, onMounted, ref ,reactive} from "vue";
+import { inject, onMounted, ref, reactive } from "vue";
 import { computed } from "@vue/reactivity";
-import CustomFieldsComponent from '@/views/Candidates/CustomFieldsComponent.vue'
-import { useAuthStore } from '@/store/auth_store';
+import { useAuthStore } from "@/store/auth_store";
 import mixpanel from "mixpanel-browser";
-import { MIXPANEL_ACTIONS, MIXPANEL_EVENTS_PROPERTIES } from "@/helpers/mixpanel_constants";
-import { ABILITY_TOKEN } from '@casl/vue';
-import { abilities, accessControlModules } from '@/helpers/AccessControl/accessControlConstants';
+import {
+  MIXPANEL_ACTIONS,
+  MIXPANEL_EVENTS_PROPERTIES
+} from "@/helpers/mixpanel_constants";
+import { ABILITY_TOKEN } from "@casl/vue";
+import {
+  abilities,
+  accessControlModules
+} from "@/helpers/AccessControl/accessControlConstants";
+import CandidateWorkHistory from "@/views/Candidates/CandidateWorkHistory.vue";
+import CandidateEducationHistory from "@/views/Candidates/CandidateEducationHistory.vue";
+import HTMLViewer from "@/components/HTMLViewer.vue";
 
 export default {
-	components: {
-		UIPageHeaderResponsive,
-		HiringStageFeedbackComponent,
-        CustomFieldsComponent,
-	},
-	props     : {
-		fromInternalPipeline     : {
-			default: false
-		},
-		candidatesColumns: {
-			default :{}
-		},
-        kanbanType : {
-            type: String,
-            default: null
-        },
+  components: {
+    UIPageHeaderResponsive,
+    HiringStageFeedbackComponent,
+    LongTextDisplayModal,
+    CandidateWorkHistory,
+    CandidateEducationHistory,
+    HTMLViewer
+  },
+  props: {
+    fromInternalPipeline: {
+      default: false
     },
-    setup(props,context) {
-        const globalData = inject("globalStore");
-        const jobData = useJobsStore();
-        const { getAcronym, getDate, dateFormat } = inject("useGlobalFunctions")();
-        const { getImageUrl, presigned_url } = useRecruitmentManager();
-        const { getCandidateNameAsPerVisibility } = useCandidates();
-        const ability = inject(ABILITY_TOKEN);
-        const authStore = useAuthStore();
-        let candidateDetailsFields = ref({});
-        let candidateFieldsVisibility = ref({});
-        let isLoading = ref(true);
-        let customColumns = ref([]);
-        let metaDataForNonSharedCandidates = ref({});
-        let showCustomColumnsForInternalPipeline = ref(false);
-        let candidateDetail = jobData.jobCandidatesById.candidateData;
-        let candidateHiringStageUpdated = ref(false);
-        globalData.candidateActionSource = 'Candidate Detail Page';
-        let candidateName = getCandidateNameAsPerVisibility(candidateFieldsVisibility.value, jobData.jobCandidatesById.candidateData);
-        candidateDetail['candidatename'] = candidateName;
-        
-        
-        const salaryType = [
-            { id: "2", label: "Annual Salary" },
-            { id: "1", label: "Monthly Salary" },
-            { id: "3", label: "Weekly Salary" },
-            { id: "4", label: "Daily Salary" },
-            { id: "5", label: "Hourly Salary" }
-        ];
-
-		
-        const visibilityExternalPipeline = computed(() => {
-            const { addedToInternalPipeline, candidateData } = jobData.jobCandidatesById;
-            const hasHiringStageLabel = candidateData.rcrm_hiring_stage_label !== undefined;
-
-            return addedToInternalPipeline && hasHiringStageLabel && checkVisiblity('candidatestatus');
-        });
-
-        const visibilityOfStage = computed(() => {
-            return (checkVisiblity('candidatestatus') && jobData.jobCandidatesById.candidateData.rcrm_hiring_stage_label!=undefined)
-        });
-        
-        const socialFieldsHasValue = computed(() => {
-			return (
-				(candidateDetail.profilelinkedin &&
-					!candidateFieldsVisibility.value.profilelinkedin) ||
-				(candidateDetail.profiletwitter &&
-					!candidateFieldsVisibility.value.profiletwitter) ||
-				(candidateDetail.profilegithub &&
-					!candidateFieldsVisibility.value.profilegithub) ||
-				(candidateDetail.profilexing &&
-					!candidateFieldsVisibility.value.profilexing) ||
-				(candidateDetail.profilefacebook &&
-					!candidateFieldsVisibility.value.profilefacebook)
-			);
-		});
-
-        const isPortalViewDisabled = computed(() => {
-            return ability.can(abilities.VIEW_PORTAL, accessControlModules.AGENCIES)
-        });
-
-        //setting reactive candidate status if changed from hiring feedback
-        jobData.$patch((state) => {
-            state.candidateHiringStages.externalPipeline = state.jobCandidatesById.candidateData.rcrm_hiring_stage_label;
-            state.candidateHiringStages.internalPipeline = state.jobCandidatesById.candidateData.vms_hiring_stage_label;
-        });
-
-        //convert comma separed skill to array
-        const candidateSkills = jobData.jobCandidatesById.candidateData.skill || "Not Available";
-        const skills = candidateSkills.split(",");
-
-        //getting candidate field value
-        function getCandidateDetail(candidateData, extraInfo = "") {
-            if (!candidateData) {
-                return "Not Available";
-            }
-            let result;
-
-            switch (extraInfo) {
-                case "salaryType": {
-                    const objSalaryType = salaryType.find(type => type.id === candidateData);
-                    result = objSalaryType ? objSalaryType.label : "Not Available";
-                    break;
-                }
-                case "fileType": {
-                    const customField = candidateData;
-                    result = jobData.jobCandidatesById.candidateData[customField] || null;
-                    break;
-                }
-                case "candidateupdatedon":
-                    result = dateFormat(candidateData);
-                    break;
-                default:
-                    result = candidateData + " " + extraInfo;
-                    break;
-            }
-
-            return result;
-        }
-
-        //getting the utl protocol for redirection
-        function getUrlProtocol(url) {
-            let isProtocol = /\b(http|https)/.test(url);
-            if (!isProtocol) {
-                url = "https://" + url;
-            }
-            return url.replace(/\/$/, "");
-        }
-
-        
-        function checkVisiblity(column) {
-            if (candidateFieldsVisibility.value[column]) {
-                return false;
-            }
-            return true;
-        }
-
-        function addToInternalPipeline(){
-            globalData.showModal['confirmationModal']=true;
-            jobData.candidateToInternalPipeline = [jobData.jobCandidatesById.candidateData];
-            mixpanel.track(MIXPANEL_ACTIONS.ADD_TO_INTERNAL_PIPELINE_BTN_CLICKED, authStore.getMixpanelDefaultProperties());
-        }
-        
-		function viewFileModal(value, modal) {
-			globalData.showModal["fileViewModal"] = true;
-            if(modal == 'showCandidateResumeModal'){
-                jobData.jobCandidatesById.candidatename = candidateName;
-                jobData.jobCandidatesById.resumefilename = value;
-                jobData.jobCandidatesById.modal = 'showCandidateResumeModal';
-            }else{
-                jobData.jobCandidatesById.customFileValue = value;
-			    jobData.jobCandidatesById.modal = 'showViewFileModal';
-            }
-        }
-
-        let sharedFields = "";
-        const candidatesData = require("@/entity_columns/candidates.js");
-
-        if(jobData.jobCandidatesById.candidateData.visibility == 1) {
-
-            for (const [key, value] of Object.entries(jobData.jobCandidatesById.candidateData)) {
-                if(key.includes('custcolumn')) {
-                    customColumns.value.push(value);
-                }
-            }
-
-            sharedFields = jobData.jobCandidatesById.candidateData.sharecandidatefields;
-
-        } else {
-
-            customColumns.value = jobData.jobCandidatesById.candidateData.custom_field_rcrm_copy;
-            sharedFields = jobData.jobCandidatesById.candidateData.sharecandidatefields;
-
-        }
-
-        metaDataForNonSharedCandidates.value = {
-            'customColumns': customColumns.value,
-            'sharedFields': sharedFields
-        }
-
-
-        let candidateColumns = candidatesData.getCandidateColumns(0, metaDataForNonSharedCandidates.value);
-
-        candidateColumns.columns.forEach(element => {
-            candidateDetailsFields.value[element.field] = element.headerName
-            candidateFieldsVisibility.value[element.field] = element.hide
-        });
-
-        let objCandidateDetailsSections = reactive({
-            isSocialLinksSectionVisible : {fields : ['profilelinkedin','profilefacebook','profiletwitter','profilegithub','profilexing'],visible:true},
-            isCandidateContactInformationSectionVisible : {fields : ['emailid','contactnumber'],visible:true},
-            isCandidatePersonalInformationSectionVisible : {fields : ['candidate_city','candidate_locality','candidatedob','willingtorelocate'],visible:true},
-            isEmploymentInformationSectionVisibile : {fields : ['workexpyr','salaryType','lastorganisation','relevantexperience'],visible:true},
-            isProfileFieldsSectionVisible : {fields : ['skill','qualification','specialization','languageskills'],visible:true},
-            isFilesSectionVisible : {fields : ['other_file_2','other_file_1','portfolio','resumefilename','coverletter','formatted_cv'],visible:true},
-        })
-
-        Object.entries(objCandidateDetailsSections).forEach(([section, sectionData]) => {
-            let visibility = false;
-            sectionData.fields.forEach((field) => {
-                visibility = visibility || !candidateFieldsVisibility.value[field] 
-            })  
-            sectionData.visible = visibility;
-        })
-
-
-        function closeCandidateDetailsModal () {
-            globalData.showModal['viewCandidateProfileModal'] = false; 
-            globalData.candidateActionSource = 'Candidate List Page';
-            context.emit('closeCandidateDetailsModal',candidateHiringStageUpdated.value);
-        }
-
-        //get url for hiring manager profile image
-        onMounted(async () => {
-            isLoading.value = true;
-            //using for loop to get presigned url for jobData.jobById.hiring_managers
-            await Promise.all(jobData.jobById.hiring_managers.map(async manager => {
-                if (manager.photo) {
-                    await getImageUrl(manager.photo, "job_details");
-                    manager.profile_url = presigned_url.value;
-                } else {
-                    manager.profile_url = null;
-                }
-            }));
-
-            isLoading.value = false;
-            mixpanel.track(MIXPANEL_EVENTS_PROPERTIES.PAGE,{
-                [MIXPANEL_ACTIONS.PAGE_NAME] : 'Candidate Details',
-                ...authStore.getMixpanelDefaultProperties()
-            });
-        });
-        function hiringStageChanged(){
-		    candidateHiringStageUpdated.value = true;
-	    }
-       
-        return {
-            globalData,
-            isfromInternalPipeline :props.fromInternalPipeline,
-            jobData,
-            candidateDetail       : jobData.jobCandidatesById.candidateData,
-            skills,
-            candidateDetailsFields,
-            getCandidateDetail,
-            getAcronym,
-            getUrlProtocol,
-            checkVisiblity,
-            getImageUrl,
-            isLoading,
-            presigned_url,
-            getDate,
-            dateFormat,
-            customColumns,
-            showCustomColumnsForInternalPipeline,
-            metaDataForNonSharedCandidates,
-            viewFileModal,
-            addToInternalPipeline,
-            visibilityInHiringStage : { 
-                                    'externalPipeline': checkVisiblity('candidatestatus'),
-                                    'remarkVisibility': checkVisiblity('remark'),
-                                    'isAddedToInternalPipeline':jobData.jobCandidatesById.addedToInternalPipeline,
-                                },      
-            visibilityExternalPipeline,
-            visibilityOfStage,
-            socialFieldsHasValue,
-            objCandidateDetailsSections,
-            abilities,
-            accessControlModules,
-            ability,
-            closeCandidateDetailsModal,
-            candidateHiringStageUpdated,
-            hiringStageChanged,
-            authStore,
-            isPortalViewDisabled
-        };
+    candidatesColumns: {
+      default: {}
+    },
+    kanbanType: {
+      type: String,
+      default: null
     }
+  },
+  setup(props, context) {
+    const globalData = inject("globalStore");
+    const jobData = useJobsStore();
+    const { getAcronym, getDate, dateFormat, isJson } = inject(
+      "useGlobalFunctions"
+    )();
+    const { getImageUrl, presigned_url } = useRecruitmentManager();
+    const { getCandidateNameAsPerVisibility } = useCandidates();
+    const ability = inject(ABILITY_TOKEN);
+    const authStore = useAuthStore();
+    let candidateDetailsFields = ref({});
+    let fields = ref({});
+    let candidateFieldsVisibility = ref({});
+    let isLoading = ref(true);
+    let customColumns = ref([]);
+    let jobCustomFields = ref([]);
+    let metaDataForNonSharedCandidates = ref({});
+    let showCustomColumnsForInternalPipeline = ref(false);
+    let candidateDetail = jobData.jobCandidatesById.candidateData;
+    let candidateHiringStageUpdated = ref(false);
+    globalData.candidateActionSource = "Candidate Detail Page";
+    let candidateName = getCandidateNameAsPerVisibility(
+      candidateFieldsVisibility.value,
+      jobData.jobCandidatesById.candidateData
+    );
+    candidateDetail["candidatename"] = candidateName;
+    let fieldsToIgnore = [
+      "profilelinkedin",
+      "profilefacebook",
+      "profiletwitter",
+      "profilegithub",
+      "profilexing",
+      "emailid",
+      "contactnumber",
+      "skill",
+      "languageskills",
+      "work_history",
+      "education_history",
+      "select_checkbox",
+      "actions"
+    ];
+    let fileTypes = [
+      "resumefilename",
+      "coverletter",
+      "portfolio",
+      "other_file_1",
+      "other_file_2",
+      "formatted_cv",
+      "summary"
+    ];
+    const showLongTextModal = ref(false);
+    const strLongTextFieldName = ref("");
+    const strLongTextFieldValue = ref("");
+    const openCandidateSummaryModal = ref(false);
+    let flagsmithData = jobData.agencyPageData["flagsmithData"][0];
+
+    const fieldDataFunctionMapping = {
+      noticeperiod: days => (days ? `${days} Days` : "Not Available"),
+      willingtorelocate: value => (value === 1 ? "Yes" : "No"),
+      salaryType: value => (value ? getSalaryType(value) : "Not Available"),
+      workexpyr: years => (years ? `${years} Years` : "0 Years"),
+      relevantexperience: years => (years ? `${years} Years` : "0 Years"),
+      genderid: value => (value ? getGenderValue(value) : "Not Available"),
+      currentsalary: value =>
+        value ? `${candidateDetail.symbol || ""} ${value}` : "Not Available",
+      salaryexpectation: value =>
+        value ? `${candidateDetail.symbol || ""} ${value}` : "Not Available",
+      skill: value => (value ? value.split(",") : ["Not Available"])
+    };
+
+    const allVisibleFieldsLength = computed(() => {
+      if (socialFieldsHasValue.value) {
+        return Object.keys(allVisibleFields.value).length + 1;
+      }
+      return Object.keys(allVisibleFields.value).length;
+    });
+
+    function getSalaryType(value) {
+      const salaryType = [
+        "Monthly Salary",
+        "Annual Salary",
+        "Weekly Salary",
+        "Daily Salary",
+        "Hourly Salary"
+      ];
+      return salaryType[value - 1];
+    }
+
+    function getGenderValue(value) {
+      const genderMapping = ["Male", "Female", "Not Available"];
+      return genderMapping[value - 1];
+    }
+
+    const languageSkillsList = computed(() => {
+      return candidateDetail.languageskills
+        ? candidateDetail.languageskills.split(",")
+        : [];
+    });
+
+    const allVisibleFields = computed(() => {
+      //remove the fields which are not visible
+      let visibleStandardFields = candidateColumns.columns.filter(column => {
+        return (
+          checkVisiblity(column.field) &&
+          column.field != "select_checkbox" &&
+          !fieldsToIgnore.includes(column.field)
+        );
+      });
+
+      //except
+
+      let visibleCustomColumns = getCustomColumns();
+      let visibleJobCustomColumns =
+        flagsmithData.jobAssociatedFieldsFlag && !props.fromInternalPipeline
+          ? getJobCustomFields()
+          : [];
+      //concat custom columns with visible fields
+      visibleCustomColumns = visibleCustomColumns.concat(
+        visibleJobCustomColumns
+      );
+
+      if (!jobData.jobCandidatesById.candidateData.visibility) {
+        setCustomDataInCandidateDetail(visibleCustomColumns);
+      }
+
+      //merge custom columns with visible fields
+      let visibleFields = visibleStandardFields.concat(visibleCustomColumns);
+
+      //except summary if props.fromInternalPipeline is true
+      if (props.fromInternalPipeline) {
+        visibleFields = visibleFields.filter(column => {
+          return column.field != "summary";
+        });
+      }
+      //sort based on order
+      visibleFields = visibleFields.sort((a, b) =>
+        a.order > b.order ? 1 : -1
+      );
+
+      let n = visibleFields.length;
+      let inputList = visibleFields;
+      let outputList = [];
+      for (let i = 0; i < n / 2; i++) {
+        outputList.push(inputList[i]);
+
+        const secondHalfIndex = i + Math.ceil(n / 2);
+        if (secondHalfIndex < n) {
+          outputList.push(inputList[secondHalfIndex]);
+        }
+      }
+
+      visibleFields = outputList;
+
+      visibleFields.forEach(element => {
+        fields.value[element.field] = {
+          label: element.headerName,
+          type: element.type ? element.type : element.column_type
+        };
+      });
+      return fields.value;
+    });
+
+    const visibilityOfStage = computed(() => {
+      return (
+        checkVisiblity("candidatestatus") &&
+        jobData.jobCandidatesById.candidateData.rcrm_hiring_stage_label !=
+          undefined
+      );
+    });
+
+    const socialFieldsHasValue = computed(() => {
+      return (
+        (candidateDetail.profilelinkedin &&
+          !candidateFieldsVisibility.value.profilelinkedin) ||
+        (candidateDetail.profiletwitter &&
+          !candidateFieldsVisibility.value.profiletwitter) ||
+        (candidateDetail.profilegithub &&
+          !candidateFieldsVisibility.value.profilegithub) ||
+        (candidateDetail.profilexing &&
+          !candidateFieldsVisibility.value.profilexing) ||
+        (candidateDetail.profilefacebook &&
+          !candidateFieldsVisibility.value.profilefacebook)
+      );
+    });
+
+    const isPortalViewDisabled = computed(() => {
+      return ability.can(abilities.VIEW_PORTAL, accessControlModules.AGENCIES);
+    });
+
+    //setting reactive candidate status if changed from hiring feedback
+    jobData.$patch(state => {
+      state.candidateHiringStages.externalPipeline =
+        state.jobCandidatesById.candidateData.rcrm_hiring_stage_label;
+      state.candidateHiringStages.internalPipeline =
+        state.jobCandidatesById.candidateData.vms_hiring_stage_label;
+    });
+
+    //getting candidate field value
+    function getCandidateDetail(value, field, type = "") {
+      if (fieldDataFunctionMapping[field]) {
+        return fieldDataFunctionMapping[field](value);
+      }
+      if (!value) {
+        return "Not Available";
+      }
+      if (type == "date") {
+        return dateFormat(value);
+      }
+      return value;
+    }
+
+    function isCustomField(columnKey) {
+      return (
+        columnKey.includes("custcolumn") ||
+        columnKey.includes("job_associated_cust_column_")
+      );
+    }
+
+    //getting the utl protocol for redirection
+    function getUrlProtocol(url) {
+      let isProtocol = /\b(http|https)/.test(url);
+      if (!isProtocol) {
+        url = "https://" + url;
+      }
+      return url.replace(/\/$/, "");
+    }
+
+    function checkVisiblity(column) {
+      if (candidateFieldsVisibility.value[column]) {
+        return false;
+      }
+      return true;
+    }
+
+    function viewFileModal(value, modal) {
+      globalData.showModal["fileViewModal"] = true;
+      if (modal == "showCandidateResumeModal") {
+        jobData.jobCandidatesById.candidatename = candidateName;
+        jobData.jobCandidatesById.resumefilename = value;
+        jobData.jobCandidatesById.modal = "showCandidateResumeModal";
+      } else {
+        jobData.jobCandidatesById.customFileValue = value;
+        jobData.jobCandidatesById.modal = "showViewFileModal";
+      }
+    }
+
+    let sharedFields = "";
+    const candidatesData = require("@/entity_columns/candidates.js");
+
+    if (jobData.jobCandidatesById.candidateData.visibility == 1) {
+      for (const [key, value] of Object.entries(
+        jobData.jobCandidatesById.candidateData
+      )) {
+        if (key.includes("custcolumn")) {
+          customColumns.value.push(value);
+        }
+        if (key.includes("job_associated_cust_column_")) {
+          jobCustomFields.value.push(value);
+        }
+      }
+
+      sharedFields =
+        jobData.jobCandidatesById.candidateData.sharecandidatefields;
+    } else {
+      customColumns.value =
+        jobData.jobCandidatesById.candidateData.custom_field_rcrm_copy;
+      sharedFields =
+        jobData.jobCandidatesById.candidateData.sharecandidatefields;
+      jobCustomFields.value =
+        jobData.jobCandidatesById.candidateData.job_associated_custom_field_rcrm_copy;
+    }
+
+    metaDataForNonSharedCandidates.value = {
+      customColumns: customColumns.value,
+      sharedFields: sharedFields,
+      jobAssociatedCustomFields: jobCustomFields.value
+    };
+
+    let candidateColumns = candidatesData.getCandidateColumns(
+      0,
+      metaDataForNonSharedCandidates.value
+    );
+
+    candidateColumns.columns.forEach(element => {
+      candidateDetailsFields.value[element.field] = element.headerName;
+      candidateFieldsVisibility.value[element.field] = element.hide;
+    });
+
+    function closeCandidateDetailsModal() {
+      globalData.showModal["viewCandidateProfileModal"] = false;
+      globalData.candidateActionSource = "Candidate List Page";
+      context.emit(
+        "closeCandidateDetailsModal",
+        candidateHiringStageUpdated.value
+      );
+    }
+
+    function setCustomDataInCandidateDetail(customFields) {
+      customFields.forEach(element => {
+        candidateDetail[element.field] = element;
+      });
+    }
+
+    function getJobCustomFields() {
+      let arrJobCustomFields = ref(
+        metaDataForNonSharedCandidates.value.jobAssociatedCustomFields
+      );
+      let sharedFields = ref(metaDataForNonSharedCandidates.value.sharedFields);
+      let visibleJobCustomFields = [];
+
+      if (isJson(sharedFields.value) && typeof sharedFields.value == "string") {
+        sharedFields.value = JSON.parse(sharedFields.value);
+      }
+      if (sharedFields.value && arrJobCustomFields.value != null) {
+        const fieldVisiblity = ref(sharedFields.value);
+        arrJobCustomFields.value.forEach(field => {
+          if (
+            field &&
+            fieldVisiblity.value[field.column_name] &&
+            field.column_name.includes("job_associated_cust_column")
+          ) {
+            if (fieldVisiblity.value[field.column_name].visible == 1) {
+              field.headerName =
+                fieldVisiblity.value[field.column_name].external_label;
+              field.order = fieldVisiblity.value[field.column_name].order;
+              field.field = field.column_name;
+              //push field name and field as object
+              visibleJobCustomFields.push({ ...field });
+            }
+          }
+        });
+      }
+      return visibleJobCustomFields;
+    }
+
+    function getCustomColumns() {
+      let arrCustomColumns = ref(
+        metaDataForNonSharedCandidates.value.customColumns
+      );
+      let sharedFields = ref(metaDataForNonSharedCandidates.value.sharedFields);
+      let visibleCustomColumns = [];
+
+      if (isJson(sharedFields.value) && typeof sharedFields.value == "string") {
+        sharedFields.value = JSON.parse(sharedFields.value);
+      }
+      if (sharedFields.value && arrCustomColumns.value != null) {
+        const fieldVisiblity = ref(sharedFields.value);
+        arrCustomColumns.value.forEach(field => {
+          if (
+            field &&
+            fieldVisiblity.value[field.column_name] &&
+            field.column_name.includes("custcolumn")
+          ) {
+            if (fieldVisiblity.value[field.column_name].visible == 1) {
+              field.headerName =
+                fieldVisiblity.value[field.column_name].external_label;
+              field.order = fieldVisiblity.value[field.column_name].order;
+              field.field = field.column_name;
+              //push field name and field as object
+              visibleCustomColumns.push({ ...field });
+            }
+          }
+        });
+      }
+      return visibleCustomColumns;
+    }
+
+    //get url for hiring manager profile image
+    onMounted(async () => {
+      isLoading.value = true;
+      //using for loop to get presigned url for jobData.jobById.hiring_managers
+      await Promise.all(
+        jobData.jobById.hiring_managers.map(async manager => {
+          if (manager.photo) {
+            await getImageUrl(manager.photo, "job_details");
+            manager.profile_url = presigned_url.value;
+          } else {
+            manager.profile_url = null;
+          }
+        })
+      );
+
+      isLoading.value = false;
+      mixpanel.track(MIXPANEL_EVENTS_PROPERTIES.PAGE, {
+        [MIXPANEL_ACTIONS.PAGE_NAME]: "Candidate Details",
+        ...authStore.getMixpanelDefaultProperties()
+      });
+    });
+    function hiringStageChanged() {
+      candidateHiringStageUpdated.value = true;
+    }
+
+    const openLongTextModal = column => {
+      strLongTextFieldName.value = column.headerName;
+      strLongTextFieldValue.value = column.column_value;
+      showLongTextModal.value = true;
+    };
+
+    const viewSummaryModal = () => {
+      openCandidateSummaryModal.value = true;
+    };
+
+    return {
+      globalData,
+      isfromInternalPipeline: props.fromInternalPipeline,
+      jobData,
+      candidateDetail: jobData.jobCandidatesById.candidateData,
+      candidateDetailsFields,
+      getCandidateDetail,
+      getAcronym,
+      getUrlProtocol,
+      checkVisiblity,
+      getImageUrl,
+      isLoading,
+      presigned_url,
+      getDate,
+      dateFormat,
+      customColumns,
+      showCustomColumnsForInternalPipeline,
+      metaDataForNonSharedCandidates,
+      viewFileModal,
+      viewSummaryModal,
+      visibilityInHiringStage: {
+        externalPipeline: checkVisiblity("candidatestatus"),
+        remarkVisibility: checkVisiblity("remark"),
+        isAddedToInternalPipeline:
+          jobData.jobCandidatesById.addedToInternalPipeline
+      },
+
+      visibilityOfStage,
+      socialFieldsHasValue,
+      abilities,
+      accessControlModules,
+      ability,
+      closeCandidateDetailsModal,
+      candidateHiringStageUpdated,
+      hiringStageChanged,
+      authStore,
+      isPortalViewDisabled,
+      allVisibleFields,
+      isCustomField,
+      showLongTextModal,
+      strLongTextFieldName,
+      strLongTextFieldValue,
+      openLongTextModal,
+      allVisibleFieldsLength,
+      fileTypes,
+      openCandidateSummaryModal,
+      languageSkillsList,
+      flagsmithData
+    };
+  }
 };
 </script>
 
 <style lang="scss" scoped>
 .stage-badge {
-    background-color: #EAF4FF;
-    color: #3A6A88;
+  background-color: #eaf4ff;
+  color: #3a6a88;
 }
 
 #pageHeader {
-    padding: 1.5rem 0rem !important;
-    border-top: none !important;
-
+  padding: 1.5rem 0rem !important;
+  border-top: none !important;
 }
 
 #leftColumn {
-    overflow: scroll !important;
-    position: absolute;
-    top: 0px;
-    bottom: 0;
-    left: 0;
-    overflow-y: scroll;
-    background-color: #f5f4f4;
+  overflow: scroll !important;
+  position: absolute;
+  top: 0px;
+  bottom: 0;
+  left: 0;
+  overflow-y: scroll;
+  background-color: #f5f4f4;
 }
 
 #rightColumn {
-    height: 100%;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    overflow-y: scroll;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  overflow-y: scroll;
+}
+.margin-check {
+  border-bottom: 1px solid #d2d7da;
+  line-height: 3.5rem;
 }
 </style>
-

--- a/src/components/Candidatedetail.vue
+++ b/src/components/Candidatedetail.vue
@@ -1170,6 +1170,7 @@ export default {
   right: 0;
   overflow-y: scroll;
 }
+
 .margin-check {
   border-bottom: 1px solid #d2d7da;
   line-height: 3.5rem;


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the candidate detail modal to improve the display of candidate information, including contact details, skills, and social links.
- Introduced new components for displaying long text fields, work history, and education history within the candidate detail modal.
- Added functionality to view candidate summaries and other relevant files directly from the modal.
- Updated the job information section to provide more comprehensive details about the job and hiring managers.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Candidatedetail.vue</strong><dd><code>Enhance Candidate Detail Modal with Additional Information and New <br>Layout</code></dd></summary>
<hr>

src/components/Candidatedetail.vue
<li>Refactored the candidate detail modal to include additional candidate <br>details and restructured the layout for better readability.<br> <li> Added new components for displaying long text fields, candidate work <br>history, and education history.<br> <li> Implemented functionality to view candidate summary and other files <br>directly from the candidate detail modal.<br> <li> Enhanced the job information section to include more detailed <br>information about the hiring managers and the job.


</details>
    

  </td>
  <td><a href="https://github.com/sushmitaCRM03/Vue-JS-Helper-pro/pull/2/files#diff-12be18893c801ca0556a91630c083b57d5e2054dafd8192483d186f8e49c1987">+1114/-692</a></td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

It seems like there were no specific changes provided in your request. Please provide details of the changes you'd like to include in the release notes for a tailored response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->